### PR TITLE
docs: add zeabur deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ amd64 and arm64 Linux binaries can be found on the [Releases](https://github.com
 <img width="200px" src="https://www.deploytodo.com/do-btn-blue-ghost.svg" alt="Deploy to DO" width="150px">
 Pending approval by DigitalOcean
 
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/STATOK)
+
 ## Gallery
 
 ![monitors](https://github.com/goksan/statusnook/assets/17437810/9bc9a023-41fc-4646-a353-0a1755ce148b)


### PR DESCRIPTION
This Pull Request add a [Zeabur](https://zeabur.com) deploy button on `README.md` to let users who want to self-host their Statusnook can deploy it with one click.

[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/STATOK)

## Demo Video

[![](https://img.youtube.com/vi/UzM32IUKSFQ/0.jpg)](https://www.youtube.com/watch?v=UzM32IUKSFQ)